### PR TITLE
Move to power-assert organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # migrate-espower-babel-to-babel-preset-power-assert
 
-Migrate [espower-babel](https://github.com/power-assert-js/espower-babel "espower-babel") to [babel-plugin-espower](https://github.com/power-assert-js/babel-plugin-espower "babel-plugin-espower").
+Migrate [espower-babel](https://github.com/power-assert-js/espower-babel "espower-babel") to [babel-preset-power-assert](https://github.com/power-assert-js/babel-preset-power-assert "babel-preset-power-assert").
 
-## Use conditions
+## Target User
 
 - Using `espower-babel`
 - Having `test/mocha.opts`

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Migrate [espower-babel](https://github.com/power-assert-js/espower-babel "espower-babel") to [babel-plugin-espower](https://github.com/power-assert-js/babel-plugin-espower "babel-plugin-espower").
 
+## Use conditions
+
+- Using `espower-babel`
+- Having `test/mocha.opts`
+- Using Babel >= 6
+
 ## Installation
 
     npm install -g migrate-espower-babel-to-babel-plugin-espower
@@ -9,65 +15,56 @@ Migrate [espower-babel](https://github.com/power-assert-js/espower-babel "espowe
 ## Usage
 
 ```sh
+$ cd project-root-dir/
 $ migrate-espower-babel-to-babel-plugin-espower
 
 Run: npm uninstall -D espower-babel
-Run: npm install -D babel-plugin-espower
+Run: npm install -D babel-preset-power-assert
 Run: npm install -D babel-register
 rewrite mocha.opts
 rewrite .babelrc
 ```
 
+### Before
+
+- using espower-babel
+
+### After
+
+- using babel-register
+- using babel-preset-power-assert
+
 ## Example
 
 ```diff
 diff --git a/.babelrc b/.babelrc
-index 7e841ee..ce17a67 100644
+index ba2a650..e7e1682 100644
 --- a/.babelrc
 +++ b/.babelrc
-@@ -1,4 +1,15 @@
- {
--    "presets": ["es2015"],
--    "plugins": ["add-module-exports"]
-+  "presets": [
-+    "es2015"
-+  ],
-+  "plugins": [
-+    "add-module-exports"
-+  ],
-+  "env": {
-+    "development": {
-+      "plugins": [
-+        "babel-plugin-espower"
-+      ]
-+    }
-+  }
- }
-\ No newline at end of file
+@@ -6,6 +6,9 @@
+     "development": {
+       "plugins": [
+         "jsdoc-to-assert"
++      ],
++      "presets": [
++        "power-assert"
+       ]
+     }
+   }
 diff --git a/package.json b/package.json
-index 7532cda..ba7ebbb 100644
+index ebafaf5..e5e1216 100644
 --- a/package.json
 +++ b/package.json
-@@ -26,7 +26,7 @@
-     "test": "test"
-   },
-   "scripts": {
--    "build": "babel src --out-dir lib --source-maps",
-+    "build": "NODE_ENV=production babel src --out-dir lib --source-maps",
-     "watch": "babel src --out-dir lib --watch --source-maps",
-     "prepublish": "npm run --if-present build",
-     "test": "mocha"
-@@ -38,8 +38,9 @@
-   "devDependencies": {
-     "babel-cli": "^6.4.0",
-     "babel-plugin-add-module-exports": "^0.1.3-alpha",
-+    "babel-plugin-espower": "^2.1.2",
-     "babel-preset-es2015": "^6.3.13",
+@@ -24,7 +24,8 @@
+     "babel-plugin-add-module-exports": "^0.1.2",
+     "babel-plugin-jsdoc-to-assert": "^1.4.0",
+     "babel-preset-es2015": "^6.6.0",
 -    "espower-babel": "^4.0.1",
++    "babel-preset-power-assert": "^1.0.0",
 +    "babel-register": "^6.7.2",
-     "mocha": "^2.3.4",
-     "power-assert": "^1.2.0"
-   },
+     "espower-loader": "^1.0.0",
+     "mocha": "^2.2.1",
+     "power-assert": "^1.0.0",
 diff --git a/test/mocha.opts b/test/mocha.opts
 index 8d0282d..b76d223 100644
 --- a/test/mocha.opts
@@ -81,7 +78,7 @@ index 8d0282d..b76d223 100644
 
 See real commit:
 
-- [chore(test): use babel-plugin-espower directly by azu · Pull Request #1 · azu/es-usage-rate](https://github.com/azu/es-usage-rate/pull/1/commits/e581cd5f2b87204aff889bc7c4db8b419d799922 "chore(test): use babel-plugin-espower directly by azu · Pull Request #1 · azu/es-usage-rate")
+- [chore(npm): use babel-preset-power-assert by azu · Pull Request #25 · azu/material-flux](https://github.com/azu/material-flux/pull/25 "chore(npm): use babel-preset-power-assert by azu · Pull Request #25 · azu/material-flux")
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# migrate-espower-babel-to-babel-plugin-espower
+# migrate-espower-babel-to-babel-preset-power-assert
 
 Migrate [espower-babel](https://github.com/power-assert-js/espower-babel "espower-babel") to [babel-plugin-espower](https://github.com/power-assert-js/babel-plugin-espower "babel-plugin-espower").
 
@@ -10,13 +10,13 @@ Migrate [espower-babel](https://github.com/power-assert-js/espower-babel "espowe
 
 ## Installation
 
-    npm install -g migrate-espower-babel-to-babel-plugin-espower
+    npm install -g migrate-espower-babel-to-babel-preset-power-assert
 
 ## Usage
 
 ```sh
 $ cd project-root-dir/
-$ migrate-espower-babel-to-babel-plugin-espower
+$ migrate-espower-babel-to-babel-preset-power-assert
 
 Run: npm uninstall -D espower-babel
 Run: npm install -D babel-preset-power-assert

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -12,23 +12,20 @@ const exec = function (command) {
         throw new Error("Fail:" + command);
     }
 };
-
+// exist config files
 const babelrcPath = path.join(process.cwd(), ".babelrc");
-if (!existSync(babelrcPath)) {
-    throw new Error("Not found .babelrc file");
-}
+const existBabelRC = existSync(babelrcPath);
 const mochaOptPath = path.join(process.cwd(), "test", "mocha.opts");
 if (!existSync(mochaOptPath)) {
     throw new Error("Not found mocha.opts file in test/ dir");
 }
-
-// read file
-const babelrc = JSON.parse(fs.readFileSync(babelrcPath, "utf-8"));
+// read files
+const babelrc = existBabelRC ? JSON.parse(fs.readFileSync(babelrcPath, "utf-8")) : {};
 const mochaOpt = fs.readFileSync(mochaOptPath, "utf-8");
 // install devDependencies
-exec('npm uninstall -D espower-babel');
-exec('npm install -D babel-plugin-espower');
-exec('npm install -D babel-register');
+exec('npm uninstall --save-dev espower-babel');
+exec('npm install --save-dev babel-preset-power-assert');
+exec('npm install --save-dev babel-register');
 // replace exist config
 /**
  * @param {string} mochaOptsContent
@@ -37,14 +34,19 @@ exec('npm install -D babel-register');
 function replaceEspowerBabelToBabelRegister(mochaOptsContent) {
     return mochaOptsContent.replace(/--compilers (.*?):espower-babel\/guess/, "--compilers $1:babel-register");
 }
+/**
+ * replace babelrc object
+ * @param {Object}babelrc
+ * @returns {Object}
+ */
 function addBabelPluginEspower(babelrc) {
     const env = babelrc["env"] || {};
     const development = env["development"] || {};
-    const plugins = development["plugins"] || [];
-    if (plugins.indexOf('babel-plugin-espower') === -1) {
-        plugins.push('babel-plugin-espower');
+    const presets = development["presets"] || [];
+    if (presets.indexOf('babel-preset-power-assert') === -1 || presets.indexOf('power-assert') === -1) {
+        presets.push('power-assert');
     }
-    development["plugins"] = plugins;
+    development["presets"] = presets;
     env["development"] = development;
     babelrc["env"] = env;
     return babelrc;

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "migrate-espower-babel-to-babel-plugin-espower",
+  "name": "migrate-espower-babel-to-babel-preset-power-assert",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/azu/migrate-espower-babel-to-babel-plugin-espower.git"
+    "url": "git+https://github.com/power-assert-js/migrate-espower-babel-to-babel-preset-power-assert.git"
   },
   "author": "azu",
   "email": "azuciao@gmail.com",
-  "homepage": "https://github.com/azu/migrate-espower-babel-to-babel-plugin-espower",
+  "homepage": "https://github.com/power-assert-js/migrate-espower-babel-to-babel-preset-power-assert",
   "license": "MIT",
   "files": [
     "bin/",
@@ -14,13 +14,13 @@
     "lib/"
   ],
   "bugs": {
-    "url": "https://github.com/azu/migrate-espower-babel-to-babel-plugin-espower/issues"
+    "url": "https://github.com/power-assert-js/migrate-espower-babel-to-babel-preset-power-assert/issues"
   },
   "version": "1.0.1",
   "description": "migration tool for espower-babel.",
   "main": "bin/cmd.js",
   "bin": {
-    "migrate-espower-babel-to-babel-plugin-espower": "bin/cmd.js"
+    "migrate-espower-babel-to-babel-preset-power-assert": "bin/cmd.js"
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
This tools migrate [espower-babel](https://github.com/power-assert-js/espower-babel) to [babel-preset-power-assert](https://github.com/twada/babel-preset-power-assert) and babel-register set.
- [x] Move repository
- [x] Update package.json
- [x] Blocker: babel-preset-power-assert will move to power-assert org. (URL changing) @twada's task
- [x] Update README link to babel-preset-power-assert
